### PR TITLE
fix for PHP 7.2

### DIFF
--- a/Console/Getargs.php
+++ b/Console/Getargs.php
@@ -221,7 +221,7 @@ class Console_Getargs
      * @return object|PEAR_Error a newly created Console_Getargs_Options
      *                           object or a PEAR_Error object on error
      */
-    function &factory($config = array(), $arguments = null)
+    static function &factory($config = array(), $arguments = null)
     {
         // Create the options object.
         $obj = new Console_Getargs_Options();
@@ -901,7 +901,13 @@ class Console_Getargs_Options
             $pos = max($pos - 1, -1);
         }
         for ($i = $pos + 1; $i <= count($this->args); $i++) {
-            $paramFull = $max <= count($this->getValue($optname)) && $max != - 1;
+            $v = $this->getValue($optname);
+            if (is_array($v)) {
+                $c = count($v);
+            } else {
+                $c = ($v ? 1 : 0);
+            }
+            $paramFull = $max <= $c && $max != - 1;
             if (isset($this->args[$i]) && $this->isValue($this->args[$i]) && !$paramFull) {
                 // Add the argument value until the next option is hit.
                 $this->updateValue($optname, $this->args[$i]);


### PR DESCRIPTION
```
$ phpunit --verbose
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.2
Configuration: /work/GIT/Console_Getargs/phpunit.xml
Error:         No code coverage driver is available

....................                                              20 / 20 (100%)

Time: 25 ms, Memory: 4,00MB

OK (20 tests, 66 assertions)

```